### PR TITLE
Stability fixes

### DIFF
--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -104,7 +104,7 @@ Otherwise, only one key-press event will be triggered.")
 #+(and sbcl x86-64)
 (defmacro without-fp-traps (&body body)
  `(sb-int:with-float-traps-masked (:invalid :divide-by-zero)
- ,@body))
+    ,@body))
 
 ;;; Do nothing on Lisps that don't need traps disabled.
 #-(and sbcl x86-64)

--- a/src/x11/glx.lisp
+++ b/src/x11/glx.lisp
@@ -182,7 +182,7 @@
   (redirect :boolean))
 
 (defun glx-create-context (dpy visual)
-  (let ((ctx (%glx-create-context dpy visual (null-pointer) 1)))
+  (let ((ctx (%glx-create-context dpy visual (null-pointer) t)))
     (when (null-pointer-p ctx)
       (error "Unable to create context"))
     ctx))


### PR DESCRIPTION
Corrects the glop-side crashes we discussed. Note that any and all calls to libGL may produce the same error; it should be recommended that OpenGL draw code be isolated and have FP traps disabled within them, if it's undesirable to disable it globally.
