### PR TITLE
bugfix: windows dont open on differernt screens

### DIFF
--- a/src/x11/glop-x11.lisp
+++ b/src/x11/glop-x11.lisp
@@ -128,8 +128,8 @@
                          (fb-config x11-window-fb-config)
                          (win-title window-title))
             win
-          (setf display (glop-xlib:x-open-display)
-                screen 0)
+          (setf display (glop-xlib:x-open-display))
+          (setf screen (glop-xlib:default-screen display))
           (multiple-value-bind (glx-major glx-minor)
               (glop-glx:glx-get-version display)
             (if (and (>= glx-major 1)

--- a/src/x11/package.lisp
+++ b/src/x11/package.lisp
@@ -4,6 +4,7 @@
   (:use #:cl #:cffi)
   (:export #:visual-info #:bool #:drawable
            #:x-open-display #:x-create-window #:x-default-root-window
+           #:default-screen
            #:x-store-name #:x-flush #:x-map-raised #:x-unmap-window
            #:x-destroy-window #:x-close-display #:x-next-event
            #:x-free #:x-intern-atom #:x-set-wm-protocols

--- a/src/x11/xlib.lisp
+++ b/src/x11/xlib.lisp
@@ -292,6 +292,9 @@
   (display-ptr :pointer)
   (screen :int))
 
+(defcfun ("XDefaultScreen" default-screen) :int
+  (display-ptr :pointer))
+
 (defcfun ("XRootWindow" root-window) :int
   (display-ptr :pointer)
   (screen :int))


### PR DESCRIPTION
The issue was that the X11 windows were not opening on different
screens. Fixing this by removing the fixed value "0" and replacing with
the default value which we get from diplay. This way we can us the value
brought in by the environment variable DISPLAY=:0.1