### PR TITLE
Search for libXcomposite.so.1 as well as libXcomposite

### DIFF
--- a/src/x11/xcomposite.lisp
+++ b/src/x11/xcomposite.lisp
@@ -2,6 +2,7 @@
 (in-package #:glop-xlib)
 
 (define-foreign-library xcomposite
+  (:unix (:or "libXcomposite.so" "libXcomposite.so.1"))
   (t (:default "libXcomposite")))
 (use-foreign-library xcomposite)
 


### PR DESCRIPTION
On ubuntu it uses libXcomposite.so.1 for some reason. This change made glop load again for me